### PR TITLE
fix: 방->메인 이동 시 카메라 시점 오류 해결

### DIFF
--- a/src/components/MainExperience.jsx
+++ b/src/components/MainExperience.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import { usePlay } from '../contexts/Play';
 import { useFrame } from "@react-three/fiber";
-import {PerspectiveCamera, useScroll} from "@react-three/drei";
+import {PerspectiveCamera, useScroll, OrbitControls} from "@react-three/drei";
 import * as THREE from "three";
 import { MainBackground } from './MainBackground';
 import { Main_Ground } from './models/Outside/MainGround';
@@ -10,6 +10,14 @@ import { useStageContext } from '../contexts/StageContext';
 // 상수 선언
 const CURVE_AHEAD_CAMERA = 0.1
 const LINE_NB_POINTS = 50
+
+const comeOutValue = [
+  {"add_offset": 0, "position": [126,3,-27]},
+  {"add_offset": 0.17, "position": [61.5,3,-8]},
+  {"add_offset": 0.42, "position": [-31,4,-28.5]},
+  {"add_offset": 0.7, "position": [-77,5,-120]},
+  {"add_offset": 0.96, "position": [-11,5,-211]}
+]
 
 
 export default function MainExperience({setShowEnterDialog}) {
@@ -20,22 +28,23 @@ export default function MainExperience({setShowEnterDialog}) {
   const sceneOpacity = 0
 
   const {play, setHasScroll, end, isFirst, setIsFirst} = usePlay()
-  const {addOffset} = useStageContext()
+  const {comeOutRoom} = useStageContext()
 
   const curvePoints = useMemo(
     () => [
       new THREE.Vector3(126,3,-27),
       new THREE.Vector3(90,3,-15),
-      new THREE.Vector3(63,3,-9),
+      new THREE.Vector3(61.5,3,-8.8), // grandma
       new THREE.Vector3(20,4,-7),
       new THREE.Vector3(0,4,-12),
-      new THREE.Vector3(-30,4,-28),
+      new THREE.Vector3(-31,4,-28.5), // man
       new THREE.Vector3(-55,5,-50),
       new THREE.Vector3(-65,5,-75),
-      new THREE.Vector3(-73,5,-105),
+      new THREE.Vector3(-77,5,-120), // woman
       new THREE.Vector3(-80,5,-145),
       new THREE.Vector3(-60,5,-185),
       new THREE.Vector3(-40,5,-203),
+      new THREE.Vector3(-11,5,-211), // player
       new THREE.Vector3(0,5,-215),
     ],
     []
@@ -94,7 +103,7 @@ export default function MainExperience({setShowEnterDialog}) {
       return;
     }
 
-    const scrollOffset = Math.max(0, scroll.offset + addOffset);
+    const scrollOffset = Math.max(0, scroll.offset + comeOutValue[comeOutRoom].add_offset);
 
     let friction = 1;
 
@@ -134,20 +143,20 @@ export default function MainExperience({setShowEnterDialog}) {
     
     // console.log("lookAt", lookAt)
     // console.log("curPoint", curPoint)
-    console.log("scrollOffset", scrollOffset)
+    // console.log("scrollOffset", scrollOffset)
     // console.log("cameraRef.current.position", cameraRef.current.position)
     // console.log("lerpedScrollOffset", lerpedScrollOffset)
     // console.log("lastScroll", lastScroll)
     // console.log("targetLookAt", lastScroll)
 
 
-    if(scroll.offset > 0.1326 - addOffset && scroll.offset < 0.17 - addOffset){
+    if(scroll.offset > 0.13 - comeOutValue[comeOutRoom].add_offset && scroll.offset < 0.16 - comeOutValue[comeOutRoom].add_offset){
       setShowEnterDialog(1)
-    }else if(scroll.offset > 0.39 - addOffset && scroll.offset < 0.415 - addOffset){
+    }else if(scroll.offset > 0.355 - comeOutValue[comeOutRoom].add_offset && scroll.offset < 0.375 - comeOutValue[comeOutRoom].add_offset){
       setShowEnterDialog(2)
-    }else if(scroll.offset > 0.68 - addOffset && scroll.offset < 0.7   - addOffset){
+    }else if(scroll.offset > 0.6 - comeOutValue[comeOutRoom].add_offset && scroll.offset < 0.65   - comeOutValue[comeOutRoom].add_offset){
       setShowEnterDialog(3)
-    }else if(scroll.offset > 0.93 - addOffset && scroll.offset < 0.96 - addOffset){
+    }else if(scroll.offset > 0.90 - comeOutValue[comeOutRoom].add_offset && scroll.offset < 0.93 - comeOutValue[comeOutRoom].add_offset){
       setShowEnterDialog(4)
     }else{
       setShowEnterDialog(0) // dialog 박스 보이지 않게
@@ -155,7 +164,8 @@ export default function MainExperience({setShowEnterDialog}) {
   })
 
   useEffect(() => {
-    lastScroll.current = addOffset
+    lastScroll.current = comeOutValue[comeOutRoom].add_offset
+    console.log("comeoutRoom", comeOutRoom)
   },[])
 
   return useMemo(() =>
@@ -163,7 +173,7 @@ export default function MainExperience({setShowEnterDialog}) {
     <>
       {/* <OrbitControls/> */}
       <directionalLight position={[0, 3, 1]} intensity={1} />
-      <group ref={cameraRef}>
+      <group ref={cameraRef} position={comeOutValue[comeOutRoom].position}>
         <MainBackground backgroundColors={backgroundColors} />
         <PerspectiveCamera position={[0,-1,0]} fov={60} makeDefault />
       </group>

--- a/src/components/ui/DialogBox.jsx
+++ b/src/components/ui/DialogBox.jsx
@@ -14,7 +14,7 @@ export default function DialogBox({messageArr, stageNum}) {
   const {setFocus} = useRoomFocus();
   const navigate = useNavigate()
   const {token} = useAuthContext()
-  const {setAddOffset} = useStageContext()
+  const {setComeOutRoom} = useStageContext()
 
     const handleOnClick = useCallback(() => {
       setMessageEnded(false);
@@ -50,21 +50,7 @@ export default function DialogBox({messageArr, stageNum}) {
     }, [curMessage, messageEnded, messageArr.length]);
 
     useEffect(() => {
-      console.log(stageNum)
-      switch (stageNum) {
-        case 1:
-          setAddOffset(0.17)
-          break;
-        case 2:
-          setAddOffset(0.42)
-          break;
-        case 3:
-          setAddOffset(0.7)
-          break;
-        case 4:
-          setAddOffset(0.96)
-          break;
-      }
+      setComeOutRoom(stageNum)
     },[])
 
   return (

--- a/src/contexts/StageContext.jsx
+++ b/src/contexts/StageContext.jsx
@@ -4,12 +4,12 @@ const StageContext = createContext()
 
 export const StageContextProvider = ({children}) => {
   const [stage, setStage] = useState({})
-  const [addOffset, setAddOffset] = useState(0)
+  const [comeOutRoom, setComeOutRoom] = useState(0)
 
   return (
     <StageContext.Provider value={{
       stage, setStage,
-      addOffset, setAddOffset
+      comeOutRoom, setComeOutRoom
     }}>
       {children}
     </StageContext.Provider>

--- a/src/pages/GrandmaRoom.jsx
+++ b/src/pages/GrandmaRoom.jsx
@@ -8,9 +8,11 @@ import { Grandmother } from '../components/models/GrandmaRoom/Grandmother';
 import { MessageArr } from '../data/grandma_script';
 import CharMainDialog from '../components/ui/CharMainDialog';
 import {useProgress} from '@react-three/drei'
+import { usePlay } from '../contexts/Play';
 
 export default function GrandmaRoom() {
   const {focus} = useRoomFocus();
+  const {setIsFirst} = usePlay()
   const [position, setPosition] = useState({ x: 10, y: 9, z: 0 });
   const [target, setTarget] = useState({ x: 0, y: -5, z: 0 });
   const { progress } = useProgress();
@@ -24,6 +26,7 @@ export default function GrandmaRoom() {
       setPosition({ x: 10, y: 9, z: 0 });
       setTarget({ x: 0, y: 5, z: 0});
     }
+    setIsFirst(false)
   },[focus])
 
   return (

--- a/src/pages/ManRoom.jsx
+++ b/src/pages/ManRoom.jsx
@@ -7,11 +7,14 @@ import { useRoomFocus } from '../contexts/RoomFocus';
 import { Man } from '../components/models/ManRoom/Man';
 import CharMainDialog from '../components/ui/CharMainDialog';
 import { MessageArr } from '../data/man_script';
+import { usePlay } from '../contexts/Play';
 
 export default function ManRoom() {
   const {focus} = useRoomFocus();
+  const {setIsFirst} = usePlay()
   const [position, setPosition] = useState({ x: 12, y: 8, z: 0 });
   const [target, setTarget] = useState({ x: 0, y: -5, z: 0 });
+
 
   useEffect(() => {
     if(focus) {
@@ -22,7 +25,9 @@ export default function ManRoom() {
       setPosition({ x: 12, y: 8, z: 0 });
       setTarget({ x: 0, y: 5, z: 0});
     }
+    setIsFirst(false)
   },[focus])
+
 
   return (
     <>

--- a/src/pages/WomanRoom.jsx
+++ b/src/pages/WomanRoom.jsx
@@ -10,6 +10,7 @@ import { Woman } from '../components/models/WomanRoom/Woman';
 
 export default function WomanRoom() {
   const {focus} = useRoomFocus();
+  const {setIsFirst} = usePlay()
   const [position, setPosition] = useState({ x: 12, y: 9, z: 0 });
   const [target, setTarget] = useState({ x: 0, y: -5, z: 0 });
 
@@ -22,6 +23,7 @@ export default function WomanRoom() {
       setPosition({ x: 12, y: 9, z: 0 });
       setTarget({ x: 0, y: 5, z: 0});
     }
+    setIsFirst(false)
   },[focus])
 
   return (


### PR DESCRIPTION
나오는 방의 stageNum 값을 받아오고 미리 설정해 놓은 stageNum에 따른 addOffset,  초기 카메라 poisiton 값을 배열에서 불러와 scrollOffset 값 설정 및 scrollOffset 값에 따른 position 값을 카메라 객체 담고 있는 group 태그에 설정